### PR TITLE
Feat/#32 TabBar 컴포넌트 구현

### DIFF
--- a/src/features/team-building/components/TabBar.tsx
+++ b/src/features/team-building/components/TabBar.tsx
@@ -1,0 +1,67 @@
+import { css } from '@emotion/react';
+import { colors } from '../../../styles/constants';
+
+export type TabItem = {
+  key: string;
+  label: string;
+};
+
+type TabsProps = {
+  items: ReadonlyArray<TabItem>;
+  activeKey: string;
+  onChange: (key: string) => void;
+};
+
+export default function TabBar({ items, activeKey, onChange }: TabsProps) {
+  return (
+    <nav css={tabsWrapCss}>
+      {items.map(item => {
+        const active = item.key === activeKey;
+        return (
+          <button key={item.key} type="button" onClick={() => onChange(item.key)}>
+            <span css={labelCss(active)}>{item.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+const tabsWrapCss = css`
+  display: flex;
+  gap: 40px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+const labelCss = (active: boolean) => css`
+  position: relative;
+
+  padding: 20px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 38.4px;
+  color: ${active ? colors.grayscale[1000] : colors.grayscale[500]};
+
+  border-bottom: 4px solid transparent;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+
+    width: 100%;
+    height: 4px;
+    background: ${colors.grayscale[1000]};
+
+    transform-origin: center;
+    transform: scaleX(${active ? 1 : 0});
+    transition: transform 0.2s ease;
+  }
+`;

--- a/src/pages/components.tsx
+++ b/src/pages/components.tsx
@@ -1,0 +1,43 @@
+/** 컴포넌트 사용 예시 확인 페이지 (지울 예정) */
+import { useState } from 'react';
+import { css } from '@emotion/react';
+
+import TabBar from '../features/team-building/components/TabBar';
+
+const MY_TABS = [
+  { key: 'profile', label: 'Profile' },
+  { key: 'project', label: 'My project' },
+  { key: 'team', label: 'My team' },
+] as const;
+
+type MyTab = (typeof MY_TABS)[number]['key'];
+
+export default function ComponentsPage() {
+  const [activeTab, setActiveTab] = useState<MyTab>('project');
+
+  return (
+    <main css={mainCss}>
+      <div css={innerCss}>
+        {/* 탭 컴포넌트 (마이페이지 사용 예시) */}
+        <TabBar
+          items={MY_TABS}
+          activeKey={activeTab}
+          onChange={key => setActiveTab(key as MyTab)}
+        />
+      </div>
+    </main>
+  );
+}
+
+const mainCss = css`
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  background: #fff;
+  padding-top: 80px;
+`;
+
+const innerCss = css`
+  width: 100%;
+`;


### PR DESCRIPTION
### 개요  

마이페이지와 프로젝트 갤러리 페이지에서 사용되는 TabBar를 재사용 가능한 컴포넌트로 분리해 구현하였습니다.
또한, (`/components`) 페이지를 임시로 생성해 마이페이지 기준으로 사용 예시 페이지도 구현하였습니다. (컴포넌트 적용 후 삭제 예정)

---


### 주요 변경사항  

- TabBar 컴포넌트 제작
- 사용 예시 페이지 생성
- color.ts 사용해 색상 적용
 
---

### 테스트 및 검증  
- 로컬 환경에서 각 화면의 입력 및 전환 플로우 정상 작동 확인 
- Lint 검증 완료

---