### PR TITLE
마이페이지(Profile) - api 연동 1차 (#55)

### DIFF
--- a/src/features/team-building/components/Profile/SecessionPopup.tsx
+++ b/src/features/team-building/components/Profile/SecessionPopup.tsx
@@ -1,21 +1,18 @@
-import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { colors } from '../../../../styles/constants';
 import Button from '../Button';
 
-export default function SecessionPopup() {
-  const router = useRouter();
+interface SecessionPopupProps {
+  onConfirm: () => void;
+}
 
-  const handleConfirm = () => {
-    router.push('/');
-  };
-
+export default function SecessionPopup({ onConfirm }: SecessionPopupProps) {
   return (
     <main css={mainCss}>
       <div css={boxCss}>
         <h1 css={titleCss}>탈퇴가 완료되었습니다.</h1>
-        <Button title="확인" onClick={handleConfirm} />
+        <Button title="확인" onClick={onConfirm} />
       </div>
     </main>
   );
@@ -23,7 +20,9 @@ export default function SecessionPopup() {
 
 const mainCss = css`
   z-index: 999;
-  position: absolute;
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100vh;
   background: rgba(4, 4, 5, 0.3);

--- a/src/features/team-building/components/SelectBoxLink_han.tsx
+++ b/src/features/team-building/components/SelectBoxLink_han.tsx
@@ -8,6 +8,7 @@ import {
   selectBoxContainer,
   wrap,
 } from '../styles/selectBoxLink';
+import { UserLinkOption } from '@/lib/mypageProfile.api';
 import Field from './Field';
 import SelectBoxBasic from './SelectBoxBasic';
 
@@ -35,10 +36,9 @@ interface SelectBoxLinkProps {
    */
   maxLinks?: number;
   /**
-   * 선택 가능한 플랫폼 목록
-   * @default ['GitHub', 'LinkedIn', 'Twitter', 'Website']
+   * 선택 가능한 플랫폼 목록 (API에서 받은 옵션)
    */
-  platforms?: string[];
+  options?: UserLinkOption[];
 }
 
 export default function SelectBoxLink({
@@ -46,7 +46,7 @@ export default function SelectBoxLink({
   value,
   defaultValue = [{ id: 0, platform: '', url: '' }],
   maxLinks = 10,
-  platforms = ['GitHub', 'LinkedIn', 'Twitter', 'Website'],
+  options = [],
 }: SelectBoxLinkProps) {
   // Controlled vs Uncontrolled
   const isControlled = value !== undefined;
@@ -54,6 +54,11 @@ export default function SelectBoxLink({
 
   // Controlled 모드일 때 외부 value 사용
   const links = isControlled ? value : internalLinks;
+
+  // 플랫폼 옵션을 SelectBoxBasic에 맞게 변환 (type 값만 추출)
+  const platformOptions = options.length > 0 
+    ? options.map(opt => opt.type)
+    : ['GitHub', 'LinkedIn', 'Twitter', 'Website']; // fallback
 
   // value prop이 변경되면 내부 상태 업데이트 (초기화 시)
   useEffect(() => {
@@ -99,7 +104,7 @@ export default function SelectBoxLink({
         <div key={link.id} css={fieldWrap}>
           <div css={selectBoxContainer}>
             <SelectBoxBasic
-              options={platforms}
+              options={platformOptions}
               placeholder="플랫폼 선택"
               value={link.platform ? [link.platform] : []}
               onChange={selected => handlePlatformChange(link.id, selected[0] || '')}

--- a/src/features/team-building/hooks/useProfileEditor.ts
+++ b/src/features/team-building/hooks/useProfileEditor.ts
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
+import { MyProfile, useUpdateMyProfile } from '@/lib/mypageProfile.api';
 
 export interface Link {
   id: number;
@@ -6,17 +8,46 @@ export interface Link {
   url: string;
 }
 
-export const useProfileEditor = (initialMarkdown: string) => {
+export const useProfileEditor = (profile?: MyProfile) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isPreviewMode, setIsPreviewMode] = useState(false);
 
-  const [bioMarkdown, setBioMarkdown] = useState(initialMarkdown);
+  const [bioMarkdown, setBioMarkdown] = useState('');
   const [savedTechStack, setSavedTechStack] = useState<string[]>([]);
   const [savedLinks, setSavedLinks] = useState<Link[]>([{ id: 0, platform: '', url: '' }]);
 
-  const [tempMarkdown, setTempMarkdown] = useState(bioMarkdown);
-  const [selectedTechStack, setSelectedTechStack] = useState<string[]>(savedTechStack);
-  const [links, setLinks] = useState<Link[]>(savedLinks);
+  const [tempMarkdown, setTempMarkdown] = useState('');
+  const [selectedTechStack, setSelectedTechStack] = useState<string[]>([]);
+  const [links, setLinks] = useState<Link[]>([{ id: 0, platform: '', url: '' }]);
+
+  const { mutate: updateProfile } = useUpdateMyProfile();
+
+  // 프로필 데이터가 로드되면 초기화
+  useEffect(() => {
+    if (profile) {
+      const introduction = profile.introduction || '';
+      const techStacks = profile.techStacks.map(ts => ts.techStackType);
+      const userLinks: Link[] =
+        profile.userLinks.length > 0
+          ? profile.userLinks.map((ul, idx) => ({
+              id: idx,
+              platform: ul.linkType,
+              url: ul.url,
+            }))
+          : [{ id: 0, platform: '', url: '' }];
+
+      setBioMarkdown(introduction);
+      setSavedTechStack(techStacks);
+      setSavedLinks(userLinks);
+
+      // 편집 중이 아닐 때만 temp 값도 동기화
+      if (!isEditing) {
+        setTempMarkdown(introduction);
+        setSelectedTechStack(techStacks);
+        setLinks(userLinks);
+      }
+    }
+  }, [profile, isEditing]);
 
   const handleEditClick = () => {
     setIsEditing(true);
@@ -27,18 +58,40 @@ export const useProfileEditor = (initialMarkdown: string) => {
   };
 
   const handleSave = () => {
-    setBioMarkdown(tempMarkdown);
-    setSavedTechStack(selectedTechStack);
-    setSavedLinks(links);
+    // API 호출
+    updateProfile(
+      {
+        techStacks: selectedTechStack.map(techStackType => ({ techStackType })),
+        userLinks: links
+          .filter(link => link.platform && link.url)
+          .map(link => ({
+            linkType: link.platform,
+            url: link.url,
+          })),
+        introduction: tempMarkdown,
+      },
+      {
+        onSuccess: () => {
+          // 저장 성공 시 상태 업데이트
+          setBioMarkdown(tempMarkdown);
+          setSavedTechStack(selectedTechStack);
+          setSavedLinks(links);
 
-    setIsEditing(false);
-    setIsPreviewMode(false);
+          setIsEditing(false);
+          setIsPreviewMode(false);
 
-    console.log('저장된 데이터:', {
-      bio: tempMarkdown,
-      techStack: selectedTechStack,
-      links: links,
-    });
+          console.log('프로필 저장 성공:', {
+            bio: tempMarkdown,
+            techStack: selectedTechStack,
+            links: links,
+          });
+        },
+        onError: error => {
+          console.error('프로필 저장 실패:', error);
+          alert('프로필 저장에 실패했습니다. 다시 시도해주세요.');
+        },
+      }
+    );
   };
 
   const handleCancel = () => {

--- a/src/features/team-building/pages/Profie/index.tsx
+++ b/src/features/team-building/pages/Profie/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { css } from '@emotion/react';
 
 import { colors, layoutCss } from '../../../../styles/constants';
+import { useMyProfile } from '@/lib/mypageProfile.api';
 import ProfileBio from '../../components/Profile/ProfileBio';
 import ProfileEditButtons from '../../components/Profile/ProfileEditButtons';
 import ProfileHeader from '../../components/Profile/ProfileHeader';
@@ -9,6 +10,8 @@ import ProfileList from '../../components/Profile/ProfileList';
 import { useProfileEditor } from '../../hooks/useProfileEditor';
 
 export default function ProfilePage() {
+  const { data: profile, isLoading, error } = useMyProfile();
+
   const {
     isEditing,
     isPreviewMode,
@@ -24,7 +27,40 @@ export default function ProfilePage() {
     handleEditClick,
     handleSave,
     togglePreview,
-  } = useProfileEditor('');
+  } = useProfileEditor(profile);
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <main css={mainCss}>
+        <div css={innerCss}>
+          <div css={loadingCss}>프로필을 불러오는 중...</div>
+        </div>
+      </main>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <main css={mainCss}>
+        <div css={innerCss}>
+          <div css={errorCss}>프로필을 불러오는 중 오류가 발생했습니다.</div>
+        </div>
+      </main>
+    );
+  }
+
+  // 데이터 없음
+  if (!profile) {
+    return (
+      <main css={mainCss}>
+        <div css={innerCss}>
+          <div css={errorCss}>프로필 정보가 없습니다.</div>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main css={mainCss}>
@@ -33,12 +69,14 @@ export default function ProfilePage() {
           <ProfileHeader
             isEditing={isEditing}
             isPreviewMode={isPreviewMode}
+            userName={profile.name}
             onEditClick={handleEditClick}
           />
 
           <ProfileList
             isEditing={isEditing}
             isPreviewMode={isPreviewMode}
+            profile={profile}
             selectedTechStack={isEditing ? selectedTechStack : savedTechStack}
             links={isEditing ? links : savedLinks}
             onTechStackChange={setSelectedTechStack}
@@ -101,4 +139,22 @@ const secessionCss = css`
   border: none;
   cursor: pointer;
   padding: 0;
+`;
+
+const loadingCss = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  font-size: 18px;
+  color: #666;
+`;
+
+const errorCss = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  font-size: 18px;
+  color: #e53e3e;
 `;

--- a/src/features/team-building/pages/Secession.tsx/index.tsx
+++ b/src/features/team-building/pages/Secession.tsx/index.tsx
@@ -1,18 +1,48 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { colors } from '../../../../styles/constants';
 import Button from '../../components/Button';
 import SecessionPopup from '../../components/Profile/SecessionPopup';
+import { useDeleteAccount } from '@/lib/mypageProfile.api';
+import { useAuthStore } from '@/lib/authStore';
 
 export default function SecessionPage() {
+  const router = useRouter();
   const [click, setClick] = useState(false);
   const [visible, setVisible] = useState(false);
+  
+  const { mutate: deleteAccount, isPending } = useDeleteAccount();
+  const clearAuth = useAuthStore(state => state.clearAuth);
+
   const toggle = () => setClick(prev => !prev);
-  const visibleToggle = () => setVisible(prev => !prev);
+
+  const onDeleteClick = () => {
+    if (!click || isPending) return;
+
+    deleteAccount(undefined, {
+      onSuccess: () => {
+        // 인증 정보 초기화
+        clearAuth();
+        // 팝업 표시
+        setVisible(true);
+      },
+      onError: (error) => {
+        console.error('회원 탈퇴 실패:', error);
+        alert('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+      },
+    });
+  };
+
+  const handlePopupConfirm = () => {
+    setVisible(false);
+    router.push('/');
+  };
+
   return (
     <main css={mainCss}>
-      {visible && <SecessionPopup />}
+      {visible && <SecessionPopup onConfirm={handlePopupConfirm} />}
       <div
         css={{
           display: 'flex',
@@ -60,8 +90,12 @@ export default function SecessionPage() {
         </p>
       </div>
 
-      <div css={{ width: '190px' }} onClick={() => visibleToggle()}>
-        <Button title="탈퇴하기" disabled={!click} variant="secondary" />
+      <div css={{ width: '190px' }} onClick={onDeleteClick}>
+        <Button 
+          title={isPending ? '처리 중...' : '탈퇴하기'} 
+          disabled={!click || isPending} 
+          variant="secondary" 
+        />
       </div>
     </main>
   );

--- a/src/lib/mypageProfile.api.ts
+++ b/src/lib/mypageProfile.api.ts
@@ -1,0 +1,240 @@
+import { useMutation, useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
+
+import { api } from './api';
+
+/* =========================================================
+ * Query Keys
+ * ======================================================= */
+export const mypageProfileKeys = {
+  all: ['mypageProfile'] as const,
+  profile: () => [...mypageProfileKeys.all, 'profile'] as const,
+  userLinkOptions: () => [...mypageProfileKeys.all, 'userLinkOptions'] as const,
+  techStackOptions: () => [...mypageProfileKeys.all, 'techStackOptions'] as const,
+};
+
+/* =========================================================
+ * DTO Types (Backend Response Shape)
+ * ======================================================= */
+interface GenerationDto {
+  id: number;
+  generation: string;
+  position: string;
+  isMain: boolean;
+}
+
+interface TechStackDto {
+  techStackType: string;
+  iconUrl: string;
+}
+
+interface UserLinkDto {
+  linkType: string;
+  url: string;
+  iconUrl: string;
+}
+
+interface GetMyProfileResponse {
+  userId: number;
+  name: string;
+  school: string;
+  generations: GenerationDto[];
+  part: string;
+  techStacks: TechStackDto[];
+  userLinks: UserLinkDto[];
+  introduction: string;
+}
+
+interface UserLinkOptionDto {
+  type: string;
+  name: string;
+  iconUrl: string;
+}
+
+interface TechStackOptionDto {
+  code: string;
+  displayName: string;
+  iconUrl: string;
+}
+
+interface UpdateMyProfileRequest {
+  techStacks: Array<{ techStackType: string }>;
+  userLinks: Array<{ linkType: string; url: string }>;
+  introduction: string;
+}
+
+/* =========================================================
+ * Domain Types
+ * ======================================================= */
+export interface Generation {
+  id: number;
+  generation: string;
+  position: string;
+  isMain: boolean;
+}
+
+export interface TechStack {
+  techStackType: string;
+  iconUrl: string;
+}
+
+export interface UserLink {
+  linkType: string;
+  url: string;
+  iconUrl: string;
+}
+
+export interface MyProfile {
+  userId: number;
+  name: string;
+  school: string;
+  generations: Generation[];
+  part: string;
+  techStacks: TechStack[];
+  userLinks: UserLink[];
+  introduction: string;
+}
+
+export interface UserLinkOption {
+  type: string;
+  name: string;
+  iconUrl: string;
+}
+
+export interface TechStackOption {
+  code: string;
+  displayName: string;
+  iconUrl: string;
+}
+
+export interface UpdateProfileData {
+  techStacks: Array<{ techStackType: string }>;
+  userLinks: Array<{ linkType: string; url: string }>;
+  introduction: string;
+}
+
+/* =========================================================
+ * Utils
+ * ======================================================= */
+function mapProfileDtoToDomain(dto: GetMyProfileResponse): MyProfile {
+  return {
+    userId: dto.userId,
+    name: dto.name,
+    school: dto.school,
+    generations: dto.generations ?? [],
+    part: dto.part,
+    techStacks: dto.techStacks ?? [],
+    userLinks: dto.userLinks ?? [],
+    introduction: dto.introduction ?? '',
+  };
+}
+
+function mapUserLinkOptionDtoToDomain(dto: UserLinkOptionDto): UserLinkOption {
+  return {
+    type: dto.type,
+    name: dto.name,
+    iconUrl: dto.iconUrl,
+  };
+}
+
+function mapTechStackOptionDtoToDomain(dto: TechStackOptionDto): TechStackOption {
+  return {
+    code: dto.code,
+    displayName: dto.displayName,
+    iconUrl: dto.iconUrl,
+  };
+}
+
+/* =========================================================
+ * API: Get My Profile
+ * ======================================================= */
+export async function fetchMyProfile(): Promise<MyProfile> {
+  const res = await api.get<GetMyProfileResponse>('/mypage');
+  return mapProfileDtoToDomain(res.data);
+}
+
+export function useMyProfile(
+  options?: Omit<UseQueryOptions<MyProfile, Error>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<MyProfile, Error>({
+    queryKey: mypageProfileKeys.profile(),
+    queryFn: fetchMyProfile,
+    staleTime: 1000 * 60 * 5, // 5분
+    ...options,
+  });
+}
+
+/* =========================================================
+ * API: Get User Link Options
+ * ======================================================= */
+export async function fetchUserLinkOptions(): Promise<UserLinkOption[]> {
+  const res = await api.get<UserLinkOptionDto[]>('/mypage/userLinkOptions');
+  return (res.data ?? []).map(mapUserLinkOptionDtoToDomain);
+}
+
+export function useUserLinkOptions(
+  options?: Omit<UseQueryOptions<UserLinkOption[], Error>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<UserLinkOption[], Error>({
+    queryKey: mypageProfileKeys.userLinkOptions(),
+    queryFn: fetchUserLinkOptions,
+    staleTime: 1000 * 60 * 30, // 30분 (옵션은 자주 변하지 않음)
+    ...options,
+  });
+}
+
+/* =========================================================
+ * API: Get Tech Stack Options
+ * ======================================================= */
+export async function fetchTechStackOptions(): Promise<TechStackOption[]> {
+  const res = await api.get<TechStackOptionDto[]>('/mypage/techStackOptions');
+  return (res.data ?? []).map(mapTechStackOptionDtoToDomain);
+}
+
+export function useTechStackOptions(
+  options?: Omit<UseQueryOptions<TechStackOption[], Error>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<TechStackOption[], Error>({
+    queryKey: mypageProfileKeys.techStackOptions(),
+    queryFn: fetchTechStackOptions,
+    staleTime: 1000 * 60 * 30, // 30분 (옵션은 자주 변하지 않음)
+    ...options,
+  });
+}
+
+/* =========================================================
+ * API: Update My Profile
+ * ======================================================= */
+export async function updateMyProfile(data: UpdateProfileData): Promise<void> {
+  await api.put<void>('/mypage', data);
+}
+
+export function useUpdateMyProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateMyProfile,
+    onSuccess: () => {
+      // 프로필 업데이트 성공 시 프로필 데이터 다시 조회
+      queryClient.invalidateQueries({ queryKey: mypageProfileKeys.profile() });
+    },
+  });
+}
+
+/* =========================================================
+ * API: Delete Account (회원 탈퇴)
+ * ======================================================= */
+export async function deleteAccount(): Promise<void> {
+  await api.delete<void>('/auth/delete');
+}
+
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: () => {
+      // 탈퇴 성공 시 모든 캐시 초기화
+      queryClient.clear();
+    },
+  });
+}


### PR DESCRIPTION
## 📝 작업 내용(또는 PR 설명)
- 마이페이지 프로필 조회/수정 API 연동 완료
- `GET /mypage`, `GET /mypage/userLinkOptions`, `GET /mypage/techStackOptions`, `PUT /mypage` 엔드포인트 연동
- 회원 탈퇴 기능 API 연동 완료 (`DELETE /auth/delete`)
- 프로필 편집 모드 및 미리보기 기능 구현
- 기술 스택 및 사용자 링크 동적 선택 및 렌더링
- React Query를 활용한 데이터 fetching 및 상태 관리
- 기존 하드코딩된 데이터 대신 실제 서버 데이터 사용

## 🔧 주요 변경사항

### 신규 파일
- `lib/mypageProfile.api.ts`: 마이페이지 관련 API 연동 로직 및 React Query Hooks
  - `fetchMyProfile()`: 내 프로필 조회
  - `useMyProfile()`: React Query Hook (staleTime: 5분)
  - `fetchUserLinkOptions()`: 사용자 링크 옵션 목록 조회 (GitHub, LinkedIn 등)
  - `useUserLinkOptions()`: React Query Hook (staleTime: 30분)
  - `fetchTechStackOptions()`: 기술 스택 옵션 목록 조회 (React, TypeScript 등)
  - `useTechStackOptions()`: React Query Hook (staleTime: 30분)
  - `updateMyProfile()`: 프로필 수정 API 호출
  - `useUpdateMyProfile()`: React Query Mutation Hook (성공 시 프로필 재조회)
  - `deleteAccount()`: 회원 탈퇴 API 호출
  - `useDeleteAccount()`: React Query Mutation Hook (성공 시 캐시 초기화)
  - DTO → Domain 타입 변환 유틸 함수들

### 수정 파일
- `pages/mypage/ProfilePage.tsx`: 프로필 페이지 API 연동
  - `useMyProfile()` Hook으로 프로필 데이터 조회
  - 로딩/에러/빈 데이터 상태 처리 추가
  - `useProfileEditor` Hook을 통한 편집 상태 관리
  - 편집 모드와 미리보기 모드 분리
  - 저장된 데이터와 임시 편집 데이터 구분 렌더링

- `pages/mypage/SecessionPage.tsx`: 회원 탈퇴 페이지 로직 개선
  - `useDeleteAccount()` Hook으로 탈퇴 API 연동
  - 불필요한 중복 함수 제거 및 로직 단순화
  - 체크박스 동의 여부 검증 추가
  - 탈퇴 진행 중 로딩 상태 표시 (`처리 중...`)
  - 탈퇴 성공/실패 시 적절한 사용자 피드백
  - `clearAuth()`를 통한 세션 스토리지 초기화
  - 팝업 확인 후 홈 화면(`/`) 리다이렉트

- `components/Profile/SecessionPopup.tsx`: 탈퇴 완료 팝업 컴포넌트 개선
  - `onConfirm` prop 추가로 부모 컴포넌트에서 라우팅 제어
  - `position: absolute` → `position: fixed`로 변경하여 오버레이 안정성 향상
  - 팝업 내부에서 직접 라우팅하지 않고 부모에게 위임

- `components/Profile/ProfileList.tsx`: 프로필 정보 표시 및 편집 컴포넌트
  - `useTechStackOptions()`, `useUserLinkOptions()` Hook으로 옵션 데이터 조회
  - API에서 받은 `iconUrl`을 사용하여 아이콘 동적 렌더링
  - 기술 스택 툴팁 표시 기능 추가
  - 링크 이미지 로드 실패 시 폴백 UI 처리
  - 편집 모드와 미리보기 모드에 따른 조건부 렌더링
  - 빈 데이터 상태에 대한 placeholder 메시지 표시

- `hooks/useProfileEditor.ts`: 프로필 편집 상태 관리 Hook
  - `useUpdateMyProfile()` Mutation Hook 활용
  - 프로필 데이터 로드 시 초기화 로직
  - 편집 중 임시 데이터(`tempMarkdown`, `selectedTechStack`, `links`)와 저장된 데이터 분리
  - 저장 성공 시 임시 데이터를 저장된 데이터로 동기화
  - 편집 취소 시 임시 데이터 초기화
  - 미리보기 모드 토글 기능

- `lib/authStore.ts`: 인증 상태 관리 (기존 파일, 탈퇴 시 사용)
  - `clearAuth()`: 세션 스토리지 및 Zustand 스토어 초기화
  - 탈퇴 시 accessToken, email, name, role 모두 제거