### PR TITLE
마이페이지(Project) - api 연동 1차 (#59)

### DIFF
--- a/src/features/team-building/components/MyProject/MyProjectCard.tsx
+++ b/src/features/team-building/components/MyProject/MyProjectCard.tsx
@@ -1,36 +1,68 @@
 import Link from 'next/link';
 import { css } from '@emotion/react';
+import React from 'react';
 
 import { colors } from '../../../../styles/constants';
-import type { Project, ProjectDetail } from '../../types/myproject';
-import { getMockProjectDetailById } from '../../types/myproject';
+import type { MyPageProject } from '@/lib/mypageProject.api';
+import { useUpdateProjectExhibit } from '@/lib/mypageProject.api';
 import Toggle from '../Toggle';
 
-type Props = { item: Project };
+type Props = { item: MyPageProject };
 
 export default function MyProjectCard({ item }: Props) {
-  const detail: ProjectDetail | null = getMockProjectDetailById(item.id);
+  const { mutate: updateExhibit, isPending } = useUpdateProjectExhibit();
+  const handleToggleExhibit = (exhibited: boolean) => {
+    updateExhibit(
+      {
+        projectId: item.projectId,
+        exhibited,
+      },
+      {
+        onSuccess: () => {
+          console.log('전시 여부가 변경되었습니다.');
+        },
+        onError: (error) => {
+          console.error('전시 여부 변경 실패:', error);
+          alert('전시 여부 변경에 실패했습니다.');
+        },
+      }
+    );
+  };
 
-  if (!detail) return null;
+  // 이미지 에러 처리
+  const handleImageError = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    e.currentTarget.src = '/gdgoc_logo.svg';
+  };
 
   return (
     <article css={articleCss}>
-      <Link href={`/project-gallery/${item.id}`}>
+      <Link href={`/project-gallery/${item.projectId}`}>
         <div css={leftSectionCss}>
           <div css={thumbFrameCss}>
-            <img src={item.thumbnailUrl} alt={item.title} css={logoCss} />
+            <img 
+              src={item.thumbnailUrl || '/gdgoc_logo.svg'} 
+              alt={item.projectName} 
+              css={logoCss}
+              onError={handleImageError}
+            />
           </div>
         </div>
       </Link>
+      
       <div css={rightSectionCss}>
         <div css={titleRowCss}>
           <div css={titleSectionCss}>
-            <h3 css={titleCss}>{detail.title}</h3>
-            <p css={descCss}>{detail.description}</p>
+            <h3 css={titleCss}>{item.projectName}</h3>
+            <p css={descCss}>{item.description}</p>
           </div>
-          {detail.isLeader && (
+          {item.isLeader && (
             <div css={displayStatusCss}>
-              전시 여부 <Toggle />
+              전시 여부{' '}
+              <Toggle 
+                checked={item.exhibited} 
+                onChange={handleToggleExhibit}
+                disabled={isPending}
+              />
             </div>
           )}
         </div>
@@ -41,34 +73,36 @@ export default function MyProjectCard({ item }: Props) {
             <span css={labelCss}>팀장</span>
             <div css={valueWrapperCss}>
               <span css={valueCss}>
-                {detail.leader.name}
-                {detail.leader.role && <span css={chipCss}>{detail.leader.role}</span>}
+                {item.leader.name}
+                <span css={chipCss}>{item.leader.part}</span>
               </span>
             </div>
           </div>
 
           {/* 팀원 */}
-          <div css={infoRowCss}>
-            <span css={labelCss}>팀원</span>
-            <div css={memberListCss}>
-              {detail.members.map((member, index) => (
-                <>
-                  <span key={index} css={memberItemCss}>
-                    {member.name}
-                    {member.role && <span css={chipCss}>{member.role}</span>}
-                  </span>
-                  {(index + 1) % 3 === 0 && index !== detail.members.length - 1 && (
-                    <div
-                      css={css`
-                        width: 100%;
-                        height: 0;
-                      `}
-                    />
-                  )}
-                </>
-              ))}
+          {item.members && item.members.length > 0 && (
+            <div css={infoRowCss}>
+              <span css={labelCss}>팀원</span>
+              <div css={memberListCss}>
+                {item.members.map((member, index) => (
+                  <React.Fragment key={member.userId}>
+                    <span css={memberItemCss}>
+                      {member.name}
+                      <span css={chipCss}>{member.part}</span>
+                    </span>
+                    {(index + 1) % 3 === 0 && index !== item.members.length - 1 && (
+                      <div
+                        css={css`
+                          width: 100%;
+                          height: 0;
+                        `}
+                      />
+                    )}
+                  </React.Fragment>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </article>
@@ -92,6 +126,7 @@ const articleCss = css`
 
 const leftSectionCss = css`
   flex-shrink: 0;
+  cursor: pointer;
 `;
 
 const thumbFrameCss = css`
@@ -103,6 +138,7 @@ const thumbFrameCss = css`
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 `;
 
 const logoCss = css`

--- a/src/features/team-building/pages/MyProject/index.tsx
+++ b/src/features/team-building/pages/MyProject/index.tsx
@@ -1,12 +1,36 @@
 import { css } from '@emotion/react';
 
 import { layoutCss } from '../../../../styles/constants';
+import { useMyPageProjects } from '@/lib/mypageProject.api';
 import MyProjectCard from '../../components/MyProject/MyProjectCard';
-import { MOCK_PROJECTS } from '../../types/myproject';
 
 export default function MyProjectPage() {
-  // MOCK_PROJECTS를 사용
-  const projects = MOCK_PROJECTS;
+  const { data: projects, isLoading, error } = useMyPageProjects();
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <main css={mainCss}>
+        <div css={innerCss}>
+          <div css={loadingCss}>프로젝트를 불러오는 중...</div>
+        </div>
+      </main>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <main css={mainCss}>
+        <div css={innerCss}>
+          <div css={errorCss}>프로젝트를 불러오는 중 오류가 발생했습니다.</div>
+        </div>
+      </main>
+    );
+  }
+
+  // 프로젝트 없음
+  const hasProjects = projects && projects.length > 0;
 
   return (
     <main css={mainCss}>
@@ -16,11 +40,16 @@ export default function MyProjectPage() {
             마이페이지 <span css={subTitleCss}>| My project</span>
           </p>
         </div>
-        <div css={projectListCss}>
-          {projects.map(project => (
-            <MyProjectCard key={project.id} item={project} />
-          ))}
-        </div>
+        
+        {hasProjects ? (
+          <div css={projectListCss}>
+            {projects.map((project) => (
+              <MyProjectCard key={project.projectId} item={project} />
+            ))}
+          </div>
+        ) : (
+          <div css={emptyStateCss}>참여한 프로젝트가 없습니다.</div>
+        )}
       </div>
     </main>
   );
@@ -67,4 +96,31 @@ const projectListCss = css`
   flex-direction: column;
   gap: 0;
   width: 100%;
+`;
+
+const loadingCss = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  font-size: 18px;
+  color: #666;
+`;
+
+const errorCss = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  font-size: 18px;
+  color: #e53e3e;
+`;
+
+const emptyStateCss = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  font-size: 20px;
+  color: #999;
 `;

--- a/src/lib/mypageProject.api.ts
+++ b/src/lib/mypageProject.api.ts
@@ -1,0 +1,118 @@
+import { useMutation, useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
+
+import { api } from './api';
+import { projectGalleryKeys } from './projectGallery.api'; // import 추가
+
+/* =========================================================
+ * Query Keys
+ * ======================================================= */
+export const mypageProjectKeys = {
+  all: ['mypageProject'] as const,
+  list: () => [...mypageProjectKeys.all, 'list'] as const,
+};
+
+/* =========================================================
+ * DTO Types (Backend Response Shape)
+ * ======================================================= */
+interface MyPageProjectMemberDto {
+  userId: number;
+  name: string;
+  part: string;
+}
+
+interface MyPageProjectDto {
+  projectId: number;
+  thumbnailImageUrl: string;
+  projectName: string;
+  exhibited: boolean;
+  shortIntroduction: string;
+  myRole: 'LEADER' | 'MEMBER';
+  leader: MyPageProjectMemberDto;
+  members: MyPageProjectMemberDto[];
+}
+
+type GetMyPageProjectsResponse = MyPageProjectDto[];
+
+interface UpdateProjectExhibitRequest {
+  projectId: number;
+  exhibited: boolean;
+}
+
+/* =========================================================
+ * Domain Types
+ * ======================================================= */
+export interface MyPageProjectMember {
+  userId: number;
+  name: string;
+  part: string;
+}
+
+export interface MyPageProject {
+  projectId: number;
+  thumbnailUrl: string;
+  projectName: string;
+  exhibited: boolean;
+  description: string;
+  isLeader: boolean;
+  leader: MyPageProjectMember;
+  members: MyPageProjectMember[];
+}
+
+/* =========================================================
+ * Utils
+ * ======================================================= */
+function mapMyPageProjectDtoToDomain(dto: MyPageProjectDto): MyPageProject {
+  return {
+    projectId: dto.projectId,
+    thumbnailUrl: dto.thumbnailImageUrl,
+    projectName: dto.projectName,
+    exhibited: dto.exhibited,
+    description: dto.shortIntroduction,
+    isLeader: dto.myRole === 'LEADER',
+    leader: dto.leader,
+    members: dto.members,
+  };
+}
+
+/* =========================================================
+ * API: Get My Page Projects
+ * ======================================================= */
+export async function fetchMyPageProjects(): Promise<MyPageProject[]> {
+  const res = await api.get<GetMyPageProjectsResponse>('/mypage/projects');
+  return (res.data ?? []).map(mapMyPageProjectDtoToDomain);
+}
+
+export function useMyPageProjects(
+  options?: Omit<UseQueryOptions<MyPageProject[], Error>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<MyPageProject[], Error>({
+    queryKey: mypageProjectKeys.list(),
+    queryFn: fetchMyPageProjects,
+    staleTime: 1000 * 60 * 5, // 5분
+    ...options,
+  });
+}
+
+/* =========================================================
+ * API: Update Project Exhibit Status (전시 여부)
+ * ======================================================= */
+export async function updateProjectExhibit(data: UpdateProjectExhibitRequest): Promise<void> {
+  await api.put(`/mypage/mypage/projects/exhibit`, {
+    projectId: data.projectId,
+    exhibited: data.exhibited,
+  });
+}
+
+export function useUpdateProjectExhibit() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateProjectExhibit,
+    onSuccess: () => {
+      // 마이 프로젝트 목록 갱신
+      queryClient.invalidateQueries({ queryKey: mypageProjectKeys.list() });
+      // 프로젝트 갤러리 목록도 갱신 (전시 여부가 변경되었으므로)
+      queryClient.invalidateQueries({ queryKey: projectGalleryKeys.all });
+    },
+  });
+}


### PR DESCRIPTION
## 📝 작업 내용(또는 PR 설명)

마이페이지의 프로젝트 목록 조회 및 전시 여부 변경 기능을 API와 연동했습니다.

### 주요 변경사항
- **마이페이지 프로젝트 API 연동**
  - `GET /mypage/projects`: 내 프로젝트 목록 조회
  - `PUT /mypage/mypage/projects/exhibit`: 프로젝트 전시 여부 변경
  - React Query를 사용한 캐싱 및 상태 관리 구현

- **프로젝트 갤러리 API 수정**
  - API 응답 구조 변경에 따른 DTO 타입 수정
  - `leader` 필드가 별도 객체로 분리되어 제공되도록 변경
  - 멤버 검색 및 상세 조회 로직 개선

- **UI 컴포넌트 개선**
  - 프로젝트 카드에 전시 여부 토글 기능 추가 (팀장만 가능)
  - 이미지 로드 실패 시 기본 이미지 fallback 처리
  - React Fragment key 누락 오류 수정
  - 로딩/에러 상태 UI 추가

### 기술적 변경사항
- `useMyPageProjects`: 프로젝트 목록 조회 훅
- `useUpdateProjectExhibit`: 전시 여부 변경 mutation 훅
- Query invalidation을 통한 프로젝트 갤러리와 마이페이지 간 데이터 동기화
