### PR TITLE
feat/#18:auth fix 필드 개별적 형식검증보완

### DIFF
--- a/src/features/team-building/pages/SignUp/index.tsx
+++ b/src/features/team-building/pages/SignUp/index.tsx
@@ -20,7 +20,6 @@ export default function SignUpPage() {
   const [pw, setPw] = useState('');
   const [pw2, setPw2] = useState('');
   const [phone, setPhone] = useState('');
-  const [touched, setTouched] = useState(false);
 
   const [school, setSchool] = useState('');
   const [cohort, setCohort] = useState('');
@@ -28,50 +27,21 @@ export default function SignUpPage() {
   const [position, setPosition] = useState<'MEMBER' | 'CORE' | 'ORGANIZER'>('MEMBER');
   const [agree, setAgree] = useState(false);
 
-  const [errors, setErrors] = useState<Record<string, string>>({});
   const [showCompleteModal, setShowCompleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
   const [duplicateType, setDuplicateType] = useState<'email' | 'phone' | null>(null);
 
-  const validateStep = useCallback(
-    (step: Step) => {
-      const newErrors: Record<string, string> = {};
+  const validateStep3 = useCallback(() => {
+    const errors: Record<string, string> = {};
 
-      if (step === 2) {
-        if (!name.trim()) newErrors.name = '이름을 입력해주세요.';
-        else if (!/^[A-Za-z가-힣]+$/.test(name))
-          newErrors.name = '이름은 영문 또는 한글만 입력 가능합니다.';
-        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
-          newErrors.email = '이메일 형식이 올바르지 않습니다.';
-        if (pw !== pw2) newErrors.pw2 = '비밀번호가 일치하지 않습니다.';
-        if (pw.length < 8) {
-          newErrors.pw = '비밀번호는 8자 이상이어야 합니다.';
-        } else if (!/[A-Za-z]/.test(pw) || !/\d/.test(pw)) {
-          newErrors.pw = '비밀번호는 영문과 숫자 특수문자를 모두 포함해야 합니다.';
-        }
-        if (!/^\d{2,3}-\d{3,4}-\d{4}$/.test(phone))
-          newErrors.phone = '전화번호 형식이 올바르지 않습니다.(예: 010-1234-5678)';
-      }
+    if (orgType !== 'internal' && !school.trim()) errors.school = '학교를 입력해주세요.';
+    if (!cohort) errors.cohort = '기수를 선택해주세요.';
+    if (!part) errors.part = '파트를 선택해주세요.';
+    if (!position) errors.position = '분류를 선택해주세요.';
+    if (!agree) errors.agree = '약관에 동의해주세요.';
 
-      if (step === 3) {
-        if (orgType !== 'internal' && !school.trim()) newErrors.school = '학교를 입력해주세요.';
-        if (!cohort) newErrors.cohort = '기수를 선택해주세요.';
-        if (!part) newErrors.part = '파트를 선택해주세요.';
-        if (!position) newErrors.position = '분류를 선택해주세요.';
-        if (!agree) newErrors.agree = '약관에 동의해주세요.';
-      }
-
-      setErrors(newErrors);
-      return Object.keys(newErrors).length === 0;
-    },
-    [name, email, pw, pw2, phone, school, cohort, part, position, agree, orgType]
-  );
-
-  useEffect(() => {
-    if (currentStep === 2 && touched) {
-      validateStep(2);
-    }
-  }, [name, email, pw, pw2, phone, touched, currentStep, validateStep]);
+    return Object.keys(errors).length === 0;
+  }, [orgType, school, cohort, part, position, agree]);
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -83,9 +53,7 @@ export default function SignUpPage() {
   }, []);
 
   const handleNext = () => {
-    if (validateStep(currentStep)) {
-      setCurrentStep(prev => (prev < 3 ? ((prev + 1) as Step) : prev));
-    }
+    setCurrentStep(prev => (prev < 3 ? ((prev + 1) as Step) : prev));
   };
 
   const handlePrev = () => {
@@ -94,7 +62,7 @@ export default function SignUpPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateStep(3)) return;
+    if (!validateStep3()) return;
 
     const userRole = orgType === 'internal' ? 'ROLE_SKHU_MEMBER' : 'ROLE_OTHERS';
     const finalSchool = orgType === 'internal' ? '성공회대학교' : school;
@@ -133,14 +101,6 @@ export default function SignUpPage() {
     }
   };
 
-  const isStep2Disabled =
-    !name.trim() ||
-    !/^[A-Za-z가-힣]+$/.test(name) ||
-    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ||
-    !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/.test(pw) ||
-    pw !== pw2 ||
-    !/^\d{2,3}-\d{3,4}-\d{4}$/.test(phone);
-
   const renderStep = () => {
     switch (currentStep) {
       case 1:
@@ -168,13 +128,9 @@ export default function SignUpPage() {
             setPw={setPw}
             setPw2={setPw2}
             setPhone={setPhone}
-            errors={errors}
             onNext={handleNext}
             onPrev={handlePrev}
-            touched={touched}
-            setTouched={setTouched}
             currentStep={currentStep}
-            isDisabled={isStep2Disabled}
           />
         );
       case 3:


### PR DESCRIPTION
## 📝 작업 내용(또는 PR 설명)
필드 개별적 형식검증 보완을 통해 특수문자가 입력되지 않았으나, 8자리 이상 입력된 경우에도 특수문자 입력에 대한 오류메시지가 추가되지않던 버그를 수정함.
이름 형식에 대한 필드의 형식검증을 백엔드와 동일하게 2-5자, 한글 및 영문만 가능 으로 수정하여 
잘못된 이름필드로 가입을 시도하는 경우를 방지하는 것으로 해결함.
미수정 : 화면상 노출되는 파트명에 대한 수정은 수정범위가 많고, 백엔드서 /를 이넘으로 입력불가한 관계로 미수정처리
개선 : 전화번호 입력시 -를 수동으로 입력하는 과정을 자동적으로 3,4,4자리 사이마다 입력되게끔 수정하여 개선함
스탭3에서 완료시 기존재 계정을 검증하고 Step2로 보내는 로직이 적용되어있음.
필드 개별적 형식검증보완

> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

#18 
## 🔍 관련 이슈
ex) #이슈번호, #이슈번호

## 📷 스크린샷(선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

